### PR TITLE
Add post meta and simple view counts

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,11 @@
 <h2>{{ .Title }}</h2>
 <ul>
 {{ range .Pages }}
-    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    <li>
+        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        <small>({{ .Date.Format "2006-01-02" }}) 조회수: <span data-slug="{{ .File.BaseFileName }}">0</span></small>
+    </li>
 {{ end }}
 </ul>
+<script src="/js/views.js"></script>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,10 @@
 {{ define "main" }}
 <article>
     <h2>{{ .Title }}</h2>
+    <p>작성일: {{ .Date.Format "2006-01-02" }}</p>
+    <p>조회수: <span id="view-count">0</span></p>
     {{ .Content }}
+    <meta name="post-slug" content="{{ .File.BaseFileName }}">
 </article>
+<script src="/js/views.js"></script>
 {{ end }}

--- a/static/js/views.js
+++ b/static/js/views.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Increase view count on single pages
+  const slugMeta = document.querySelector('meta[name="post-slug"]');
+  if (slugMeta) {
+    const slug = slugMeta.getAttribute('content');
+    const key = `view:${slug}`;
+    let count = parseInt(localStorage.getItem(key) || '0', 10);
+    count += 1;
+    localStorage.setItem(key, count);
+    const viewEl = document.getElementById('view-count');
+    if (viewEl) viewEl.textContent = count;
+  }
+
+  // Fill view counts on list pages
+  document.querySelectorAll('[data-slug]').forEach((span) => {
+    const slug = span.getAttribute('data-slug');
+    const key = `view:${slug}`;
+    const count = localStorage.getItem(key) || '0';
+    span.textContent = count;
+  });
+});


### PR DESCRIPTION
## Summary
- show publication date and per-post view count on the post list
- display date and view count on each post page
- track view counts in `localStorage` via new `views.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68712d11ad8c8323b1ba03ee29d8f0d6