### PR TITLE
Add personal writing category

### DIFF
--- a/"b/content/posts/\352\270\200\354\223\260\352\270\260.md"
+++ b/"b/content/posts/\352\270\200\354\223\260\352\270\260.md"
@@ -1,0 +1,10 @@
++++
+title = "글쓰기"
+date = 2025-07-20T00:00:00+09:00
+draft = false
+categories = ["writing"]
+tags = ["글쓰기"]
++++
+
+글쓰기를 위한 테스트 포스트입니다.
+

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -3,7 +3,7 @@
     <div class="container">
         <header class="page-header">
             <h1 class="page-title">Posts</h1>
-            <p class="page-description">종교, 철학, 공학에 대한 생각과 통찰을 나눕니다</p>
+            <p class="page-description">종교, 철학, 공학, 글쓰기에 대한 생각과 통찰을 나눕니다</p>
             
             <!-- 카테고리 필터 버튼 -->
             <div class="category-filters">
@@ -22,6 +22,10 @@
                 <button class="filter-btn" data-category="engineering">
                     <span class="icon">⚙️</span>
                     <span>공학</span>
+                </button>
+                <button class="filter-btn" data-category="writing">
+                    <span class="icon">✍️</span>
+                    <span>글쓰기</span>
                 </button>
             </div>
         </header>
@@ -183,6 +187,58 @@
                         {{ end }}
                     {{ else }}
                         <p class="no-posts">아직 공학 카테고리의 글이 없습니다.</p>
+                    {{ end }}
+                </div>
+            </section>
+
+            <!-- 글쓰기 섹션 -->
+            <section class="category-section" data-category="writing">
+                <div class="category-header">
+                    <h2 class="category-title">
+                        <span class="category-icon">✍️</span>
+                        글쓰기 (Writing)
+                    </h2>
+                    <p class="category-description">개인적인 생각과 글을 모았습니다</p>
+                </div>
+
+                <div class="posts-grid">
+                    {{ $writingPosts := where .Site.RegularPages "Params.categories" "intersect" (slice "writing") }}
+                    {{ if $writingPosts }}
+                        {{ range $writingPosts }}
+                        <article class="post-card" data-category="writing">
+                            <div class="post-category-header">
+                                <span class="category-icon">✍️</span>
+                                <span class="category-name">글쓰기</span>
+                            </div>
+                            <div class="post-card-body">
+                                <div class="post-date">
+                                    <span class="month">{{ .Date.Format "1월" }}</span>
+                                    <span class="day">{{ .Date.Format "2일" }}</span>
+                                    <span class="year">{{ .Date.Format "2006" }}</span>
+                                </div>
+                                <div class="post-content">
+                                    <h3 class="post-title">
+                                        <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+                                    </h3>
+                                    {{ with .Summary }}
+                                    <p class="post-summary">{{ . | plainify }}</p>
+                                    {{ end }}
+                                    <div class="post-footer">
+                                        <a href="{{ .RelPermalink }}" class="read-more">읽기 →</a>
+                                        {{ with .Params.tags }}
+                                        <div class="post-tags">
+                                            {{ range first 3 . }}
+                                            <span class="tag">#{{ . }}</span>
+                                            {{ end }}
+                                        </div>
+                                        {{ end }}
+                                    </div>
+                                </div>
+                            </div>
+                        </article>
+                        {{ end }}
+                    {{ else }}
+                        <p class="no-posts">아직 글쓰기 카테고리의 글이 없습니다.</p>
                     {{ end }}
                 </div>
             </section>
@@ -393,6 +449,11 @@
     color: #065f46;
 }
 
+.post-card[data-category="writing"] .post-category-header {
+    background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+    color: #92400e;
+}
+
 .dark .post-card[data-category="religion"] .post-category-header {
     background: linear-gradient(135deg, #1e3a8a 0%, #1e40af 100%);
     color: #dbeafe;
@@ -406,6 +467,11 @@
 .dark .post-card[data-category="engineering"] .post-category-header {
     background: linear-gradient(135deg, #064e3b 0%, #065f46 100%);
     color: #d1fae5;
+}
+
+.dark .post-card[data-category="writing"] .post-category-header {
+    background: linear-gradient(135deg, #78350f 0%, #92400e 100%);
+    color: #fef3c7;
 }
 
 .post-category-header .category-icon {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,9 +6,9 @@
                 <span class="title-main">The Logos</span>
                 <span class="title-divider">✦</span>
             </h1>
-            <p class="hero-subtitle">Religion · Philosophy · Engineering</p>
+            <p class="hero-subtitle">Religion · Philosophy · Engineering · Writing</p>
             <div class="hero-description">
-                <p>종교, 철학, 공학의 교차점에서 탐구하는 블로그입니다.</p>
+                <p>종교, 철학, 공학, 글쓰기의 교차점에서 탐구하는 블로그입니다.</p>
                 <p>인간의 정신적 차원과 기술적 진보가 만나는 지점을 탐색합니다.</p>
             </div>
             <div class="hero-actions">
@@ -49,6 +49,7 @@
                             {{ if eq . "religion" }}🕊️ 종교
                             {{ else if eq . "philosophy" }}🤔 철학
                             {{ else if eq . "engineering" }}⚙️ 공학
+                            {{ else if eq . "writing" }}✍️ 글쓰기
                             {{ else }}{{ . }}{{ end }}
                         </span>
                         {{ end }}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -16,8 +16,8 @@ collections:
     fields:
       - {label: "제목", name: "title", widget: "string"}
       - {label: "게시일", name: "date", widget: "datetime"}
-      - {label: "카테고리", name: "categories", widget: "select", 
-         options: ["religion", "philosophy", "engineering"],
+      - {label: "카테고리", name: "categories", widget: "select",
+         options: ["religion", "philosophy", "engineering", "writing"],
          multiple: true}
       - {label: "태그", name: "tags", widget: "list"}
       - {label: "설명", name: "description", widget: "text"}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -34,3 +34,8 @@
     background: rgba(34, 197, 94, 0.1);
     color: #22c55e;
 }
+
+.sub-menu a[href*="writing"]:hover {
+    background: rgba(250, 204, 21, 0.1);
+    color: #facc15;
+}


### PR DESCRIPTION
## Summary
- support a new "writing" category across the site and CMS configuration
- tag the "글쓰기" post and homepage with the new category and styling

## Testing
- `hugo --minify` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `snap install hugo --classic` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68989acf1314832387f560f204163ccb