### PR TITLE
chore: update hugo version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -29,7 +29,7 @@ jobs:
           
       - uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.125.3'
+          hugo-version: '0.148.2'
           extended: true
 
       - name: Build site


### PR DESCRIPTION
## Summary
- update Pages workflow to use Hugo 0.148.2

## Testing
- `hugo version`
- `hugo --gc --minify --destination /tmp/public`


------
https://chatgpt.com/codex/tasks/task_e_68a073e3d5e48323bfb64ee62993ad2e