### PR TITLE
fix: correct JSON-LD context URL

### DIFF
--- a/content/posts/hello-hugo.md
+++ b/content/posts/hello-hugo.md
@@ -5,7 +5,7 @@ title = 'Hello Hugo'
 +++
 <script type="application/ld+json">
 {
-  "@context": "https://https://thelogos.dev/",
+  "@context": "https://thelogos.dev/",
   "@type": "BlogPosting",
   "headline": "Religion, Philosophy, Engineering",
   "author": {


### PR DESCRIPTION
## Summary
- fix duplicated protocol in Hello Hugo post's JSON-LD `@context`
- confirm no other posts use incorrect `@context`

## Testing
- `hugo --destination /tmp/public`


------
https://chatgpt.com/codex/tasks/task_e_68b6428e18488323b35f1ce07c4a8d61